### PR TITLE
changed "quey" to "query"

### DIFF
--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -177,7 +177,7 @@ I don't think I have ever passed a variable to the queryFn that was _not_ part o
 
 ##### A new cache entry
 
-Because the quey key is used as a key for the cache, you will get a new cache entry when you switch from
+Because the query key is used as a key for the cache, you will get a new cache entry when you switch from
 'all' to 'done', and that will result in a hard loading state (probably showing a loading spinner)
 when you switch for the first time.
 This is certainly not ideal, so you can either use the _keepPreviousData_ option for these cases,


### PR DESCRIPTION
Fixed typo by changing the word `quey` to `query`