### PR TITLE
fix: code typo

### DIFF
--- a/content/posts/usestate-vs-usereducer/index.mdx
+++ b/content/posts/usestate-vs-usereducer/index.mdx
@@ -210,7 +210,7 @@ All of that would happen _inside_ the reducer. Compare that to an example where 
 
 ```jsx:title=🚨-dumb-reducer
 const reducer = (state, action) => {
-  switch (action.payload) {
+  switch (action.type) {
     // 🚨 dumb reducer that doesn't do anything, logic is in the ui
     case 'set':
       return action.value


### PR DESCRIPTION
great post, thanks for your great work! I just wanted to fix you dumb-reducer action object to match your action object used in the render function. { type, value } instead of { payload, value } :)