### PR TITLE
Fix a mention of wrong mutation function

### DIFF
--- a/content/posts/react-query-mutations/index.mdx
+++ b/content/posts/react-query-mutations/index.mdx
@@ -249,7 +249,7 @@ const onSubmit = async () => {
 }
 ```
 
-Handling errors is not necessary with _mutate_, because React Query catches (and discards) the error for you internally. It is literally implemented with: *mutateAsync().catch(noop)*😎
+Handling errors is not necessary with _mutate_, because React Query catches (and discards) the error for you internally. It is literally implemented with: *mutate().catch(noop)*😎
 
 The only situations where I've found _mutateAsync_ to be superior is when you really need the Promise for the sake of having a Promise. This can be necessary if you want to fire off multiple mutations concurrently and want to wait for them all to be finished, or if you have dependent mutations where you'd get into callback hell with the callbacks.
 


### PR DESCRIPTION
Fix the 'noop' example to use 'mutate' instead of 'mutateAsync' as it makes more sense based on the context and the actual implementation of the 'mutate' function in https://github.com/tannerlinsley/react-query/blob/master/src/react/useMutation.ts#L112.