### PR TITLE
redirect image requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   status = 301
 
 [[redirects]]
+  from = "/images/*"
+  to = "/blog/images/:splat"
+  status = 301
+
+[[redirects]]
   from = "/js/script.js"
   to = "https://plausible.io/js/plausible.js"
   status = 200


### PR DESCRIPTION
when you go to tkdodo.eu, we make requests to tkdodo.eu/images for the premium sponsors; this kinda happens before the request to /blog, so those are invalid requests; redirecting those requests to /blog/images seems right