### PR TITLE
fix: missing closing parentheses in code snippet

### DIFF
--- a/content/posts/testing-react-query/index.mdx
+++ b/content/posts/testing-react-query/index.mdx
@@ -108,7 +108,7 @@ test("my first test", async () => {
   const { result } = renderHook(() => useCustomHook(), {
     wrapper: createWrapper()
   })
-}
+})
 ```
 
 ### For components


### PR DESCRIPTION
The end of the block requires a ')' to close the 'test('