### PR TITLE
fix: no-reduce link to no-array-reduce

### DIFF
--- a/content/posts/why-i-dont-like-reduce/index.mdx
+++ b/content/posts/why-i-dont-like-reduce/index.mdx
@@ -22,7 +22,7 @@ import Translations from 'components/Translations'
 ---
 
 The popular [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) recently added a
-[no-reduce](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-reduce.md) rule, and it is set to _error_ per default.
+[no-array-reduce](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-reduce.md) rule, and it is set to _error_ per default.
 The argument is that Array.reduce will likely result in code that is hard to reason about, and can be replaced with other methods in most cases
 (Read [this twitter thread](https://twitter.com/jaffathecake/status/1213077702300852224) for a lengthy discussion if you like).
 


### PR DESCRIPTION
eslint-plugin-unicorn has named the rule `no-reduce` as `no-array-reduce`.