### PR TITLE
fix: links to reacttraining post

### DIFF
--- a/content/posts/dont-over-usestate/index.mdx
+++ b/content/posts/dont-over-usestate/index.mdx
@@ -166,7 +166,7 @@ https://twitter.com/sophiebits/status/1293710971274289152
 This is solid advice, and I'd go even further and suggest that unless we have proven that the calculation is expensive,
 I wouldn't even bother to memoize it. Don't prematurely optimize, always measure first.
 We want to have proof that something is slow before acting on it. For more on this topic, I highly recommend
-[this article by @ryanflorence](https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578).
+[this article by @ryanflorence](https://reacttraining.com/blog/react-inline-functions-and-performance).
 
 In my world, the example would look just like this:
 

--- a/content/posts/react-query-render-optimizations/index.mdx
+++ b/content/posts/react-query-render-optimizations/index.mdx
@@ -60,7 +60,7 @@ import Translations from 'components/Translations'
 **Disclaimer**: Render optimizations are an advanced concept for any app. React Query already comes with very good optimizations and defaults out of the box, and most of the time, no further optimizations are needed. "Unneeded re-renders" is a topic that many people tend to put a lot of focus on, which is why I've decided to cover it. But I wanted to point out once again, that usually, for most apps, render optimizations probably don't matter as much as you'd think. Re-renders are a good thing. They make sure your app is up-to-date. I'd take an "unnecessary re-render" over a "missing render-that-should-have-been-there" all day every day. For more on this topic, please read:
 
 - [Fix the slow render before you fix the re-render](https://kentcdodds.com/blog/fix-the-slow-render-before-you-fix-the-re-render) by Kent C. Dodds
-- [this article by @ryanflorence about premature optimizations](https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578)
+- [this article by @ryanflorence about premature optimizations](https://reacttraining.com/blog/react-inline-functions-and-performance)
 
 ---
 

--- a/content/posts/why-i-dont-like-reduce/index.mdx
+++ b/content/posts/why-i-dont-like-reduce/index.mdx
@@ -149,7 +149,7 @@ Even when working with very large lists (tens of thousands of entries),
 I have made the experience that performance is rarely negatively impacted as long as you keep iterations linear.
 
 If your toObject util does _one_ iteration with a reduce or _two_ iterations with a _map_ followed by _Object.fromEntries_ is irrelevant,
-_unless_ you have [measured it](https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578)
+_unless_ you have [measured it](https://reacttraining.com/blog/react-inline-functions-and-performance)
 and found it to be a bottleneck.
 
 ## Reduce performance pitfalls


### PR DESCRIPTION
Seems reacttraining.com website had changed their routing slightly. This should help.