### PR TITLE
add Japanese translation to react query as a state manager

### DIFF
--- a/content/posts/react-query-state-management/index.mdx
+++ b/content/posts/react-query-state-management/index.mdx
@@ -49,6 +49,10 @@ import Translations from 'components/Translations'
       language: 'Português',
       url: 'https://dbrno.vercel.app/pt-BR/blog/react-query-as-a-state-manager',
     },
+    {
+      language: '日本語',
+      url: 'https://makotot.dev/posts/react-query-as-a-state-manager-translation-ja',
+    },
   ]}
 </Translations>
 


### PR DESCRIPTION
I translated https://tkdodo.eu/blog/react-query-as-a-state-manager into Japanese. 