### PR TITLE
fix: react-query korean translations link

### DIFF
--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -39,7 +39,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-01/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-01/',
     },
     {
       language: '正體中文',

--- a/content/posts/react-query-data-transformations/index.mdx
+++ b/content/posts/react-query-data-transformations/index.mdx
@@ -42,7 +42,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-02/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-02/',
     },
     {
       language: '正體中文',

--- a/content/posts/react-query-effective-query-keys/index.mdx
+++ b/content/posts/react-query-effective-query-keys/index.mdx
@@ -51,7 +51,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-08/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-08/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-error-handling/index.mdx
+++ b/content/posts/react-query-error-handling/index.mdx
@@ -43,7 +43,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-12/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-12/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-forms/index.mdx
+++ b/content/posts/react-query-forms/index.mdx
@@ -42,7 +42,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-15/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-15/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-leveraging-query-context/index.mdx
+++ b/content/posts/react-query-leveraging-query-context/index.mdx
@@ -48,7 +48,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-09/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-09/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-mutations/index.mdx
+++ b/content/posts/react-query-mutations/index.mdx
@@ -44,7 +44,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-13/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-13/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-offline/index.mdx
+++ b/content/posts/react-query-offline/index.mdx
@@ -46,7 +46,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-14/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-14/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-placeholder-and-initial-data/index.mdx
+++ b/content/posts/react-query-placeholder-and-initial-data/index.mdx
@@ -42,7 +42,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-10/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-10/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-render-optimizations/index.mdx
+++ b/content/posts/react-query-render-optimizations/index.mdx
@@ -47,7 +47,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-03/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-03/',
     },
     {
       language: '正體中文',

--- a/content/posts/react-query-state-management/index.mdx
+++ b/content/posts/react-query-state-management/index.mdx
@@ -43,7 +43,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-11/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-11/',
     },
     {
       language: 'Português',

--- a/content/posts/react-query-typescript/index.mdx
+++ b/content/posts/react-query-typescript/index.mdx
@@ -46,7 +46,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-06/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-06/',
     },
   ]}
 </Translations>

--- a/content/posts/react-query-websockets/index.mdx
+++ b/content/posts/react-query-websockets/index.mdx
@@ -42,7 +42,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-07/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-07/',
     },
   ]}
 </Translations>

--- a/content/posts/status-checks-in-react-query/index.mdx
+++ b/content/posts/status-checks-in-react-query/index.mdx
@@ -47,7 +47,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-04/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-04/',
     },
     {
       language: 'Español',

--- a/content/posts/testing-react-query/index.mdx
+++ b/content/posts/testing-react-query/index.mdx
@@ -47,7 +47,7 @@ import Translations from 'components/Translations'
   {[
     {
       language: '한국어',
-      url: 'https://parang.tech/react/2022-react-05/',
+      url: 'https://parang.gatsbyjs.io/react/2022-react-05/',
     },
     {
       language: 'Português',


### PR DESCRIPTION
Hello, @TkDodo! The blog domain with the Korean translation has expired, so `parang.tech` It changed to `parang.gatsbyjs.io`.

I am sending you a PR by modifying the link to the Korean translation part. I'm always reading it thankfully!❤️