### PR TITLE
docs: translate inside react query to korean

### DIFF
--- a/content/posts/inside-react-query/index.mdx
+++ b/content/posts/inside-react-query/index.mdx
@@ -43,7 +43,14 @@ import Translations from 'components/Translations'
 
 ---
 
-<Translations>{[]}</Translations>
+<Translations>
+  {[
+    {
+      language: '한국어',
+      url: 'https://velog.io/@hyunjine/Inside-React-Query',
+    },
+  ]}
+</Translations>
 
 ---
 


### PR DESCRIPTION
I translate [Inside React Query](https://tkdodo.eu/blog/inside-react-query) into Korean.

https://velog.io/@hyunjine/Inside-React-Query