### PR TITLE
Fix spaces in "Array Types in TypeScript"

### DIFF
--- a/content/posts/array-types-in-typescript/index.mdx
+++ b/content/posts/array-types-in-typescript/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Array Types in TypeScript
-description: is string[] really better than Array<string> ? Of course not!
+description: is string[] really better than Array<string>? Of course not!
 date: 2023-08-19
 banner: ./array-vs-generic.jpg
 tags:
@@ -68,7 +68,7 @@ Whenever this question comes up and someone prefers the array notation, I show t
 
 ## It's shorter
 
-That's it. That's the advantage.Fewer characters to write. As if keeping code short was ever a good indicator for maintainability. `let` has fewer characters than `const` - does that mean we use `let` everywhere? Okay, I'm aware of _that_ debate as well, but let's not go there too. 😂
+That's it. That's the advantage. Fewer characters to write. As if keeping code short was ever a good indicator for maintainability. `let` has fewer characters than `const` - does that mean we use `let` everywhere? Okay, I'm aware of _that_ debate as well, but let's not go there too. 😂
 
 But seriously - `i` is shorter than `index`, `d` is shorter than `dashboard` and so on. Something being short does not make it better. We know that we read code way more often than we write it, so we shouldn't focus on making it easy to write - it should be easy to read, which brings me right to the first advantage of the generic notation:
 
@@ -84,7 +84,7 @@ function add(items: Array<string>, newItem: string)
 function add(items: string[], newItem: string)
 ```
 
-This is especially important if the type in our array is rather long, e.g.because it was inferred from somewhere. IDEs usually show array types with the array notation, so sometimes, when I hover over an array of objects, I get this:
+This is especially important if the type in our array is rather long, e.g. because it was inferred from somewhere. IDEs usually show array types with the array notation, so sometimes, when I hover over an array of objects, I get this:
 
 ```ts:title=options-array
 const options: {


### PR DESCRIPTION
Continue work done in https://github.com/TkDodo/blog/pull/226