### PR TITLE
feat: align tables slow example better with zustand solution

### DIFF
--- a/content/posts/uphill-battle-of-memoization/index.mdx
+++ b/content/posts/uphill-battle-of-memoization/index.mdx
@@ -223,7 +223,9 @@ function App() {
     <div>
       <Table1 data={state.table1Data} />
       <Table2 data={state.table2Data} />
-      <SummaryBar data={calculateSummary(state.table1Data, state.table2Data)} />
+      <SummaryBar
+        data={calculateSummary(state.table1Data, state.table2Data)}
+      />
     </div>
   )
 }

--- a/content/posts/uphill-battle-of-memoization/index.mdx
+++ b/content/posts/uphill-battle-of-memoization/index.mdx
@@ -223,7 +223,7 @@ function App() {
     <div>
       <Table1 data={state.table1Data} />
       <Table2 data={state.table2Data} />
-      <SummaryBar />
+      <SummaryBar data={calculateSummary(state.table1Data, state.table2Data)} />
     </div>
   )
 }


### PR DESCRIPTION
The slow tables example currently does not even access the state, maybe it would be better to access the state?