### PR TITLE
card border flicker on theme switch

### DIFF
--- a/src/@lekoarts/gatsby-theme-minimal-blog/components/listing.tsx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/components/listing.tsx
@@ -62,7 +62,7 @@ const CardListItem = ({
       sx={(t) => ({
         maxWidth: '320px',
         borderRadius: '12px',
-        border: `2px solid ${t.colors.background}`,
+        border: '2px solid transparent',
         padding: '8px',
         '&:hover, &:active, &:focus': {
           border: `2px solid ${t.colors.primary}`,


### PR DESCRIPTION
Switching themes on your blog has a minor "flicker" on cards borders due to CSS transitions which don't seem to be applied on borders, just making it transparent seems to fix it and it can't be removed entirely because of hovers

Sorry for nit picking, just some ocd. And thanks for your amazing work for the community!