### PR TITLE
fix: add missing protocol in mono lisa links

### DIFF
--- a/src/components/MonoLisa.tsx
+++ b/src/components/MonoLisa.tsx
@@ -10,7 +10,7 @@ const MonoLisa = () => {
         <Link
           target="_blank"
           rel="noopener noreferrer"
-          href="www.monolisa.dev/?ref=dominik"
+          href="https://www.monolisa.dev/?ref=dominik"
         >
           monolisa.dev
         </Link>

--- a/src/components/PremiumSponsors.tsx
+++ b/src/components/PremiumSponsors.tsx
@@ -178,7 +178,7 @@ const PremiumSponsors = () => (
         }}
       />
       <Link
-        href="www.monolisa.dev/?ref=dominik"
+        href="https://www.monolisa.dev/?ref=dominik"
         target="_blank"
         rel="noopener noreferrer"
         sx={{

--- a/src/components/Sponsors.tsx
+++ b/src/components/Sponsors.tsx
@@ -143,7 +143,7 @@ const Sponsors = () => (
       </Card>
       <Card>
         <Link
-          href="www.monolisa.dev/?ref=dominik"
+          href="https://www.monolisa.dev/?ref=dominik"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
👋 Just noticed the url to the `mono lisa` font was broken when I tried accessing it from your blog, because it's missing a protocol part so it resolves to a relative path. 

<img width="939" alt="Screenshot 2023-12-11 at 16 01 39" src="https://github.com/TkDodo/blog/assets/16135480/ca9fe671-316d-45ea-bdca-9fb1330a8c7e">
