### PR TITLE
Modify korean translation link of your react-query posts

### DIFF
--- a/content/posts/effective-react-query-keys/index.mdx
+++ b/content/posts/effective-react-query-keys/index.mdx
@@ -29,7 +29,7 @@ import Highlight from 'components/Highlight'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-08/',
+      url: 'https://highjoon-dev.vercel.app/blogs/8-effective-react-query-keys/',
     },
     {
       language: '日本語',

--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -28,7 +28,7 @@ import Attribution from 'components/Attribution'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-01/',
+      url: 'https://highjoon-dev.vercel.app/blogs/1-practical-react-query/',
     },
     {
       language: '正體中文',

--- a/content/posts/react-query-and-type-script/index.mdx
+++ b/content/posts/react-query-and-type-script/index.mdx
@@ -32,7 +32,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-06/',
+      url: 'https://highjoon-dev.vercel.app/blogs/6-react-query-and-typescript/',
     },
     {
       language: 'Español',

--- a/content/posts/react-query-data-transformations/index.mdx
+++ b/content/posts/react-query-data-transformations/index.mdx
@@ -31,7 +31,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-02/',
+      url: 'https://highjoon-dev.vercel.app/blogs/2-react-query-data-transformations/',
     },
     {
       language: '正體中文',

--- a/content/posts/react-query-render-optimizations/index.mdx
+++ b/content/posts/react-query-render-optimizations/index.mdx
@@ -31,7 +31,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-03/',
+      url: 'https://highjoon-dev.vercel.app/blogs/3-react-query-render-optimizations/',
     },
     {
       language: '正體中文',

--- a/content/posts/status-checks-in-react-query/index.mdx
+++ b/content/posts/status-checks-in-react-query/index.mdx
@@ -31,7 +31,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-04/',
+      url: 'https://highjoon-dev.vercel.app/blogs/4-status-checks-in-react-query/',
     },
     {
       language: 'Español',

--- a/content/posts/testing-react-query/index.mdx
+++ b/content/posts/testing-react-query/index.mdx
@@ -31,7 +31,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-05/',
+      url: 'https://highjoon-dev.vercel.app/blogs/5-testing-react-query/',
     },
     {
       language: 'Português',

--- a/content/posts/using-web-sockets-with-react-query/index.mdx
+++ b/content/posts/using-web-sockets-with-react-query/index.mdx
@@ -25,7 +25,7 @@ import { RqToc } from 'components/rq-toc'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-07/',
+      url: 'https://highjoon-dev.vercel.app/blogs/7-using-websockets-with-react-query/',
     },
     {
       language: 'Español',


### PR DESCRIPTION
It seems the Korean translation link for some of the React Query posts is not functioning correctly. I've been trying to find out how to contact the translator, but I can't find a way to do so. 

Therefore, I created a new pull request for asking you to modify the links on the Korean translation page.