### PR TITLE
Modify korean translation link of your react-query posts

### DIFF
--- a/content/posts/placeholder-and-initial-data-in-react-query/index.mdx
+++ b/content/posts/placeholder-and-initial-data-in-react-query/index.mdx
@@ -28,7 +28,7 @@ import { RqToc } from 'components/rq-toc'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-10/',
+      url: 'https://highjoon-dev.vercel.app/blogs/9-placeholder-and-initial-data-in-react-query',
     },
     {
       language: 'Español',

--- a/content/posts/react-query-as-a-state-manager/index.mdx
+++ b/content/posts/react-query-as-a-state-manager/index.mdx
@@ -29,7 +29,7 @@ import { RqToc } from 'components/rq-toc'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-11/',
+      url: 'https://highjoon-dev.vercel.app/blogs/10-react-query-as-a-state-manager',
     },
     {
       language: 'Português',

--- a/content/posts/react-query-error-handling/index.mdx
+++ b/content/posts/react-query-error-handling/index.mdx
@@ -29,7 +29,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-12/',
+      url: 'https://highjoon-dev.vercel.app/blogs/11-react-query-error-handling',
     },
   ]}
 </Translations>


### PR DESCRIPTION
Hello, I've created a pull request to request modifications to the links in the Korean translation documents for the following pages:

https://tkdodo.eu/blog/placeholder-and-initial-data-in-react-query
https://tkdodo.eu/blog/react-query-as-a-state-manager
https://tkdodo.eu/blog/react-query-error-handling