### PR TITLE
modify korean translation link of react-query posts

### DIFF
--- a/content/posts/mastering-mutations-in-react-query/index.mdx
+++ b/content/posts/mastering-mutations-in-react-query/index.mdx
@@ -30,7 +30,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-13/',
+      url: 'http://highjoon-dev.vercel.app/blogs/12-mastering-mutations-in-react-query',
     },
   ]}
 </Translations>

--- a/content/posts/offline-react-query/index.mdx
+++ b/content/posts/offline-react-query/index.mdx
@@ -29,7 +29,7 @@ import { RqToc } from 'components/rq-toc'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-14/',
+      url: 'https://highjoon-dev.vercel.app/blogs/13-offline-react-query',
     },
     {
       language: '简体中文',

--- a/content/posts/react-query-and-forms/index.mdx
+++ b/content/posts/react-query-and-forms/index.mdx
@@ -29,7 +29,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-15/',
+      url: 'https://highjoon-dev.vercel.app/blogs/14-react-query-and-forms',
     },
   ]}
 </Translations>


### PR DESCRIPTION
Hello, I've created a pull request to request modifications to the links in the Korean translation documents for the following pages:

https://tkdodo.eu/blog/mastering-mutations-in-react-query
https://tkdodo.eu/blog/offline-react-query
https://tkdodo.eu/blog/react-query-and-forms