### PR TITLE
chore: fix typo

### DIFF
--- a/content/posts/react-19-and-suspense-a-drama-in-3-acts/index.mdx
+++ b/content/posts/react-19-and-suspense-a-drama-in-3-acts/index.mdx
@@ -118,7 +118,7 @@ So after the React 19 upgrade in React Query itself, I continued working on the 
 ```jsx:title=suspense-with-two-children
 export default function App() {
   return (
-    <Suspense fallback={fallback={<p>...</p>}}>
+    <Suspense fallback={<p>...</p>}>
       <RepoData name="tanstack/query" />
       <RepoData name="tanstack/table" />
     </Suspense>


### PR DESCRIPTION
```jsx
<Suspense fallback={fallback={<p>...</p>}}>
```

Remove the inner `fallback={}`