### PR TITLE
Update react-query-meets-react-router - index.mdx

### DIFF
--- a/content/posts/react-query-meets-react-router/index.mdx
+++ b/content/posts/react-query-meets-react-router/index.mdx
@@ -312,7 +312,7 @@ If multiple invalidations are involved, you can also mix and match the two appro
 
 I'm very excited about the new React Router release. It's a great step forward to enable all applications to trigger fetches as early as possible. However, it is not a replacement for caching - so go ahead and combine React Router with React Query to get the best of both worlds. 🚀
 
-If you want to explore this topic some more, I've implemented the app from the tutorial and added React Query on top of it - you can find it in [the examples of the official docs](https://tanstack.com/query/v4/docs/examples/react/react-router).
+If you want to explore this topic some more, I've implemented the app from the tutorial and added React Query on top of it - you can find it in [the examples of the official docs](https://tanstack.com/query/latest/docs/framework/react/examples/react-router).
 
 ---
 


### PR DESCRIPTION
Update link to react-router example in tanstack-query docs.

Reason: current link is for an older version of the docs and is broken leading to a 404.