### PR TITLE
Bluesky migration

### DIFF
--- a/content/posts/2021-in-review/index.mdx
+++ b/content/posts/2021-in-review/index.mdx
@@ -216,7 +216,7 @@ I'm quite excited for what lies ahead. With React 18 and React Query v4 around t
 
 For 2022, I _really_ want to rewrite my blog, and go away from [gatsby](https://www.gatsbyjs.com/) towards either [next.js](https://nextjs.org/) or [remix.run](https://remix.run/) - or whichever framework will be all the rage next year. I don't want to do this because I'm unsatisfied with gatsby (I'm not), but more so for the technical challenge and to keep up-to-date with the latest developments on how to build stuff.
 
-So let me know in the comments below ⬇️ (or reach out to me on [twitter](https://twitter.com/tkdodo)) what you think I should be choosing and why. I really hope I find the time to get around to it 😀.
+So let me know in the comments below ⬇️ (or reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)) what you think I should be choosing and why. I really hope I find the time to get around to it 😀.
 
 With that, all that is left for me to say is merry Christmas 🎄 (if you are celebrating it), a happy new year 🎊, and I hope you say safe and healthy ⛑. I will be taking about two weeks time off to hopefully come back refreshed next year.
 

--- a/content/posts/2022-in-review/index.mdx
+++ b/content/posts/2022-in-review/index.mdx
@@ -198,7 +198,7 @@ History has shown that I'm bad at predicting the future, so I'm not trying to do
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/2023-in-review/index.mdx
+++ b/content/posts/2023-in-review/index.mdx
@@ -158,7 +158,7 @@ Apart from that, I won't even try to predict the future. One thing I can say is 
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/about-async-functions/index.mdx
+++ b/content/posts/about-async-functions/index.mdx
@@ -219,7 +219,7 @@ Have a look at [this great article](https://jakearchibald.com/2017/await-vs-retu
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/always-provide-customer-value/index.mdx
+++ b/content/posts/always-provide-customer-value/index.mdx
@@ -94,7 +94,7 @@ How on earth can you get everyone on board for such an endeavor? This will be th
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/array-types-in-type-script/index.mdx
+++ b/content/posts/array-types-in-type-script/index.mdx
@@ -237,7 +237,7 @@ Maybe this article can help to convince the community that the generic notation 
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/automatic-query-invalidation-after-mutations/index.mdx
+++ b/content/posts/automatic-query-invalidation-after-mutations/index.mdx
@@ -295,7 +295,7 @@ I hope by showing all these possibilities, it's a bit clearer why we have nothin
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/avoiding-hydration-mismatches-with-use-sync-external-store/index.mdx
+++ b/content/posts/avoiding-hydration-mismatches-with-use-sync-external-store/index.mdx
@@ -215,7 +215,7 @@ In the future, [HTTP Client hints](https://developer.mozilla.org/en-US/docs/Web/
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/avoiding-use-effect-with-callback-refs/index.mdx
+++ b/content/posts/avoiding-use-effect-with-callback-refs/index.mdx
@@ -193,7 +193,7 @@ So please, if you need to interact with DOM nodes directly after they rendered, 
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/beware-the-leaking-any/index.mdx
+++ b/content/posts/beware-the-leaking-any/index.mdx
@@ -203,7 +203,7 @@ The best advice I can give for situations where you have to use _any_ is to keep
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/breaking-react-querys-api-on-purpose/index.mdx
+++ b/content/posts/breaking-react-querys-api-on-purpose/index.mdx
@@ -342,7 +342,7 @@ That's why it's better to _not_ have this API in the first place, and that's why
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/component-composition-is-great-btw/index.mdx
+++ b/content/posts/component-composition-is-great-btw/index.mdx
@@ -351,7 +351,7 @@ Maybe this post is more about early returns than it is about component compositi
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/effective-react-query-keys/index.mdx
+++ b/content/posts/effective-react-query-keys/index.mdx
@@ -291,7 +291,7 @@ queryClient.prefetchQueries({
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/hooks-dependencies-and-stale-closures/index.mdx
+++ b/content/posts/hooks-dependencies-and-stale-closures/index.mdx
@@ -266,7 +266,7 @@ The best thing you can do is: Don't get yourself in this situation by lying abou
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/how-can-i/index.mdx
+++ b/content/posts/how-can-i/index.mdx
@@ -103,7 +103,7 @@ Both approaches should get you to the "thing" in question that is causing your i
 
 ---
 
-I'm happy to take your questions now. On [twitter](https://twitter.com/tkdodo), [github](https://github.com/tkdodo), [stackoverflow](https://stackoverflow.com/users/8405310/tkdodo) or right here in the comments below. And if you ever see me respond like this, you know you've just asked an XY question 😉
+I'm happy to take your questions now. On [bluesky](https://bsky.app/profile/tkdodo.eu), [github](https://github.com/tkdodo), [stackoverflow](https://stackoverflow.com/users/8405310/tkdodo) or right here in the comments below. And if you ever see me respond like this, you know you've just asked an XY question 😉
 
 <img src="./use-case.png" />
 

--- a/content/posts/how-infinite-queries-work/index.mdx
+++ b/content/posts/how-infinite-queries-work/index.mdx
@@ -240,7 +240,7 @@ Of course I added a regression in that PR and broke [tRPC v11](https://trpc.io/)
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/inside-react-query/index.mdx
+++ b/content/posts/inside-react-query/index.mdx
@@ -151,7 +151,7 @@ What's the same for all flows is that most of the logic happens outside of React
 
 ---
 
-I hope it's now a bit clearer how React Query works internally. As always, feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+I hope it's now a bit clearer how React Query works internally. As always, feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/introducing-x-state-store/index.mdx
+++ b/content/posts/introducing-x-state-store/index.mdx
@@ -149,7 +149,7 @@ When my article [working with zustand](working-with-zustand) came out, it was ve
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/leveraging-the-query-function-context/index.mdx
+++ b/content/posts/leveraging-the-query-function-context/index.mdx
@@ -302,7 +302,7 @@ As always: it depends. I've been loving this approach lately (which is why I wan
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/mastering-mutations-in-react-query/index.mdx
+++ b/content/posts/mastering-mutations-in-react-query/index.mdx
@@ -334,7 +334,7 @@ updateTodo.mutate(
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/offline-react-query/index.mdx
+++ b/content/posts/offline-react-query/index.mdx
@@ -145,7 +145,7 @@ What you do with that new status is up to you. I'm excited to see which ux peopl
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/optional-vs-undefined/index.mdx
+++ b/content/posts/optional-vs-undefined/index.mdx
@@ -151,7 +151,7 @@ Required, but potentially _undefined_ does not have the same intent as _optional
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/oss-feature-decision-tree/index.mdx
+++ b/content/posts/oss-feature-decision-tree/index.mdx
@@ -148,7 +148,7 @@ Only then - ship it!
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/placeholder-and-initial-data-in-react-query/index.mdx
+++ b/content/posts/placeholder-and-initial-data-in-react-query/index.mdx
@@ -163,7 +163,7 @@ As always, that is totally up to you. I personally like to use `initialData` whe
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/please-stop-using-barrel-files/index.mdx
+++ b/content/posts/please-stop-using-barrel-files/index.mdx
@@ -123,7 +123,7 @@ Where barrels are necessary is when you are writing a library. Libraries like `@
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-19-and-suspense-a-drama-in-3-acts/index.mdx
+++ b/content/posts/react-19-and-suspense-a-drama-in-3-acts/index.mdx
@@ -379,7 +379,7 @@ Like so many others before me have figured out: interactions in person are alway
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-and-forms/index.mdx
+++ b/content/posts/react-query-and-forms/index.mdx
@@ -320,7 +320,7 @@ function PersonDetail({ id }) {
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-and-react-context/index.mdx
+++ b/content/posts/react-query-and-react-context/index.mdx
@@ -239,7 +239,7 @@ and TypeScript will be happy about it. 🎉
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-and-type-script/index.mdx
+++ b/content/posts/react-query-and-type-script/index.mdx
@@ -458,7 +458,7 @@ I think this shows quite well why `unknown` is such a great (and underused) type
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-api-design-lessons-learned/index.mdx
+++ b/content/posts/react-query-api-design-lessons-learned/index.mdx
@@ -33,7 +33,7 @@ Here are the slides + transcript from the talk I recently gave at the [React Adv
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-as-a-state-manager/index.mdx
+++ b/content/posts/react-query-as-a-state-manager/index.mdx
@@ -254,7 +254,7 @@ React Query is great at managing async state globally in your app, if you let it
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-data-transformations/index.mdx
+++ b/content/posts/react-query-data-transformations/index.mdx
@@ -232,7 +232,7 @@ But if you pass a selector, you are now only subscribed to the result of the sel
 
 ---
 
-That's all I have for today 👋. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's all I have for today 👋. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu),
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-error-handling/index.mdx
+++ b/content/posts/react-query-error-handling/index.mdx
@@ -243,7 +243,7 @@ const queryClient = new QueryClient({
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-fa-qs/index.mdx
+++ b/content/posts/react-query-fa-qs/index.mdx
@@ -452,7 +452,7 @@ const { data } = useQuery({
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-meets-react-router/index.mdx
+++ b/content/posts/react-query-meets-react-router/index.mdx
@@ -316,7 +316,7 @@ If you want to explore this topic some more, I've implemented the app from the t
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/react-query-render-optimizations/index.mdx
+++ b/content/posts/react-query-render-optimizations/index.mdx
@@ -241,7 +241,7 @@ Have a look at the [replaceEqualDeep tests](https://github.com/tannerlinsley/rea
 
 ---
 
-Phew, this was quite a handful. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+Phew, this was quite a handful. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️ I'm always happy to help!
 
 <Comments />

--- a/content/posts/refactor-impactfully/index.mdx
+++ b/content/posts/refactor-impactfully/index.mdx
@@ -73,7 +73,7 @@ Try not to fall into that trap when choosing what to refactor. Be mindful about 
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/refs-events-and-escape-hatches/index.mdx
+++ b/content/posts/refs-events-and-escape-hatches/index.mdx
@@ -226,7 +226,7 @@ You can use it until React ships their own hook, but be aware that you have to i
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/road-to-refactoring/index.mdx
+++ b/content/posts/road-to-refactoring/index.mdx
@@ -103,7 +103,7 @@ So when is the right time to refactor the horrible thing we've found? I'll try t
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/seeding-the-query-cache/index.mdx
+++ b/content/posts/seeding-the-query-cache/index.mdx
@@ -274,7 +274,7 @@ Keep in mind that both approaches only work well if the structure of your detail
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/status-checks-in-react-query/index.mdx
+++ b/content/posts/status-checks-in-react-query/index.mdx
@@ -133,6 +133,6 @@ Special thanks go to [Niek Bosch](https://github.com/boschni) who first highligh
 
 ---
 
-Feel free to reach out to me on [twitter](https://twitter.com/tkdodo) if you have any questions, or just leave a comment below ⬇️
+Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu) if you have any questions, or just leave a comment below ⬇️
 
 <Comments withSeparator={false} />

--- a/content/posts/testing-react-query/index.mdx
+++ b/content/posts/testing-react-query/index.mdx
@@ -282,7 +282,7 @@ I've set up a quick repository where all of this comes nicely together: mock-ser
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/the-query-options-api/index.mdx
+++ b/content/posts/the-query-options-api/index.mdx
@@ -272,7 +272,7 @@ It contains a mix of key-only entries that we can use to build a hierarchy and f
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/the-uphill-battle-of-memoization/index.mdx
+++ b/content/posts/the-uphill-battle-of-memoization/index.mdx
@@ -279,7 +279,7 @@ The React team has also hinted that they are working on a compiler called [React
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/thinking-in-react-query/index.mdx
+++ b/content/posts/thinking-in-react-query/index.mdx
@@ -37,7 +37,7 @@ Today's article comes in a different form: it's the slides + transcript from a t
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/type-safe-react-query/index.mdx
+++ b/content/posts/type-safe-react-query/index.mdx
@@ -246,7 +246,7 @@ With that, types on the frontend can be inferred from whatever the backend produ
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/use-state-for-one-time-initializations/index.mdx
+++ b/content/posts/use-state-for-one-time-initializations/index.mdx
@@ -127,6 +127,6 @@ Honestly, I don't know why you should do it this way - I think this looks rather
 
 ---
 
-Leave a comment below ⬇️ or reach out to me on [twitter](https://twitter.com/tkdodo) if you have any questions.
+Leave a comment below ⬇️ or reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu) if you have any questions.
 
 <Comments />

--- a/content/posts/use-state-vs-use-reducer/index.mdx
+++ b/content/posts/use-state-vs-use-reducer/index.mdx
@@ -315,7 +315,7 @@ In summary, my rule of thumb of when to use what would be:
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/use-urgency/index.mdx
+++ b/content/posts/use-urgency/index.mdx
@@ -51,7 +51,7 @@ Whatever driver you may find - make sure to use the moment wisely to communicate
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/using-web-sockets-with-react-query/index.mdx
+++ b/content/posts/using-web-sockets-with-react-query/index.mdx
@@ -187,7 +187,7 @@ const queryClient = new QueryClient({
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/why-react-isnt-dying/index.mdx
+++ b/content/posts/why-react-isnt-dying/index.mdx
@@ -116,7 +116,7 @@ Because it's not dying.
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/why-you-want-react-query/index.mdx
+++ b/content/posts/why-you-want-react-query/index.mdx
@@ -417,7 +417,7 @@ Just take the `signal` you get into the `queryFn`, forward it to `fetch`, and re
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/working-with-zustand/index.mdx
+++ b/content/posts/working-with-zustand/index.mdx
@@ -210,7 +210,7 @@ Here, the applied filters _drive_ the query, because they are part of the query 
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/you-might-not-need-react-query/index.mdx
+++ b/content/posts/you-might-not-need-react-query/index.mdx
@@ -178,7 +178,7 @@ But reports of React Query's death are greatly exaggerated.
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/content/posts/zustand-and-react-context/index.mdx
+++ b/content/posts/zustand-and-react-context/index.mdx
@@ -195,7 +195,7 @@ So even though the [zustand docs](https://docs.pmnd.rs/zustand/getting-started/i
 
 ---
 
-That's it for today. Feel free to reach out to me on [twitter](https://twitter.com/tkdodo)
+That's it for today. Feel free to reach out to me on [bluesky](https://bsky.app/profile/tkdodo.eu)
 if you have any questions, or just leave a comment below. ⬇️
 
 <Comments />

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,8 +119,8 @@ module.exports = {
         ],
         externalLinks: [
           {
-            name: `Twitter`,
-            url: `https://twitter.com/tkdodo`,
+            name: `Bluesky`,
+            url: `https://bsky.app/profile/tkdodo.eu`,
           },
           {
             name: `Github`,

--- a/src/components/thinking-in-react-query/index.tsx
+++ b/src/components/thinking-in-react-query/index.tsx
@@ -533,11 +533,11 @@ const slides: ReadonlyArray<React.ReactNode> = [
   <p>
     So, that's all I got, thanks for listening. Be sure to follow me on{' '}
     <Link
-      href="https://twitter.com/tkdodo"
+      href="https://bsky.app/profile/tkdodo.eu"
       target="_blank"
       rel="noreferrer noopener"
     >
-      twitter
+      bluesky
     </Link>
     , and subscribe to my{' '}
     <Link


### PR DESCRIPTION
Per https://bsky.app/profile/tkdodo.eu/post/3lc4ojtf4hk2l

Only direct links to twitter.com/tkdodo are being replaced here. links to old posts are not being touched. nor are links to other peoples twitter profiles or posts (run `grep -Pho "https://twitter\.com/[a-zA-Z0-9_]+" content/posts/**/*.mdx | sort | uniq` to get a list)

one link is left in the 2022 review talking about how you quadrupled your follower count that year. I'll have to defer to you on how to handle that situation.

Assuming you go ahead with https://bsky.app/profile/tkdodo.eu/post/3lbyfidgwm22b it would make sense to do a blog post alongside these changes (Josh's article [here](https://www.joshuakgoldberg.com/blog/why-im-migrating-from-x-to-bluesky/) seems like a good template)