### PR TITLE
External bsky links pass 1

### DIFF
--- a/content/posts/2021-in-review/index.mdx
+++ b/content/posts/2021-in-review/index.mdx
@@ -147,7 +147,7 @@ DaiShi's answer to my question why this was suggested was: Because it will be _r
 
 🤯
 
-After that, the discussion escalated a bit, as the redux team around [Mark Erkison](https://twitter.com/acemarke) as well as react maintainers like [Brian Vaughn](https://twitter.com/brian_d_vaughn) got pulled in as well. Eventually, the discussion moved towards the [React 18 Working Group](https://github.com/reactwg/react-18/discussions/84), which I was later also invited to, where the hook was renamed to _useSyncExternalStore_, and the api was adjusted so that selector stability was no longer required.
+After that, the discussion escalated a bit, as the redux team around [Mark Erkison](https://bsky.app/profile/acemarke.dev) as well as react maintainers like [Brian Vaughn](https://twitter.com/brian_d_vaughn) got pulled in as well. Eventually, the discussion moved towards the [React 18 Working Group](https://github.com/reactwg/react-18/discussions/84), which I was later also invited to, where the hook was renamed to _useSyncExternalStore_, and the api was adjusted so that selector stability was no longer required.
 
 I'm glad my little tweet kicked off the discussion that led to this decision, which probably avoided massive breaking changes for many consumers. Just imagine having to memoize every inline selector in redux 😮. I do however regret the tone in which I voiced my concerns - I'm really sorry for that.
 

--- a/content/posts/2021-in-review/index.mdx
+++ b/content/posts/2021-in-review/index.mdx
@@ -147,7 +147,7 @@ DaiShi's answer to my question why this was suggested was: Because it will be _r
 
 🤯
 
-After that, the discussion escalated a bit, as the redux team around [Mark Erkison](https://bsky.app/profile/acemarke.dev) as well as react maintainers like [Brian Vaughn](https://twitter.com/brian_d_vaughn) got pulled in as well. Eventually, the discussion moved towards the [React 18 Working Group](https://github.com/reactwg/react-18/discussions/84), which I was later also invited to, where the hook was renamed to _useSyncExternalStore_, and the api was adjusted so that selector stability was no longer required.
+After that, the discussion escalated a bit, as the redux team around [Mark Erkison](https://bsky.app/profile/acemarke.dev) as well as react maintainers like [Brian Vaughn](https://bsky.app/profile/brian.blue) got pulled in as well. Eventually, the discussion moved towards the [React 18 Working Group](https://github.com/reactwg/react-18/discussions/84), which I was later also invited to, where the hook was renamed to _useSyncExternalStore_, and the api was adjusted so that selector stability was no longer required.
 
 I'm glad my little tweet kicked off the discussion that led to this decision, which probably avoided massive breaking changes for many consumers. Just imagine having to memoize every inline selector in redux 😮. I do however regret the tone in which I voiced my concerns - I'm really sorry for that.
 

--- a/content/posts/2022-in-review/index.mdx
+++ b/content/posts/2022-in-review/index.mdx
@@ -164,7 +164,7 @@ There is no better way to learn than to make mistakes. I've learned a lot from t
 
 Producing content has always been something I like to do, but I've generally limited myself to written content so far.
 
-This changed when [Jason Lengstorf](https://twitter.com/jlengstorf) invited me to [Learn with Jason](https://www.learnwithjason.dev/) to talk about TanStack Query. In case you missed the stream, you can [watch the recording here](https://www.learnwithjason.dev/tanstack-query-v4). It was super well received and a lot of fun for me, too. At times during the stream, it really felt like I was just talking to Jason, and I really enjoyed that.
+This changed when [Jason Lengstorf](https://bsky.app/profile/jason.energy) invited me to [Learn with Jason](https://www.learnwithjason.dev/) to talk about TanStack Query. In case you missed the stream, you can [watch the recording here](https://www.learnwithjason.dev/tanstack-query-v4). It was super well received and a lot of fun for me, too. At times during the stream, it really felt like I was just talking to Jason, and I really enjoyed that.
 
 This experience led me to think that I should do more streaming, so I've taken the opportunity to set up a [twitch account](https://www.twitch.tv/tkdodo23) and already published a first two-hour stream of me working on a feature for TanStack Query v5. You can watch the recording [on YouTube](https://youtu.be/wGxWFLFWcSA). I'm happy that people like this form of my content as well, and I'm looking forward to doing more of it next year.
 

--- a/content/posts/putting-props-to-use-state/index.mdx
+++ b/content/posts/putting-props-to-use-state/index.mdx
@@ -433,7 +433,7 @@ but it might not always be easily doable in large applications.
 Whatever you decide, please, don't use the syncing state "solution".
 To me, this approach is similar to the old _componentWillReceiveProps_ lifecycle, which was also used to sync props with state.
 I don't recall that ending well. [Here](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html)
-is a very good article from 2018 by [Brian Vaughn](https://twitter.com/brian_d_vaughn) on that anti-pattern,
+is a very good article from 2018 by [Brian Vaughn](https://bsky.app/profile/brian.blue) on that anti-pattern,
 which also heavily inspired this article.
 
 ---

--- a/content/posts/simplifying-use-effect/index.mdx
+++ b/content/posts/simplifying-use-effect/index.mdx
@@ -30,7 +30,7 @@ import Translations from 'components/Translations'
   ]}
 </Translations>
 
-[useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect). The hook everybody needs, but nobody wants. According to the official react docs, it's "_an escape hatch from React’s purely functional world into the imperative world_". The [complete guide to useEffect](https://overreacted.io/a-complete-guide-to-useeffect/) by Redux author and React core team member [Dan Abramov](https://twitter.com/dan_abramov) is a 49 minute read - and it takes at least twice the time to _really_ comprehend it.
+[useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect). The hook everybody needs, but nobody wants. According to the official react docs, it's "_an escape hatch from React’s purely functional world into the imperative world_". The [complete guide to useEffect](https://overreacted.io/a-complete-guide-to-useeffect/) by Redux author and React core team member [Dan Abramov]( https://bsky.app/profile/danabra.mov) is a 49 minute read - and it takes at least twice the time to _really_ comprehend it.
 
 useEffect is about as complex as it can get in ReactJs, and it is very unlikely that you can write an application without it. So let's try and apply some good principles to make working with useEffect more manageable:
 

--- a/content/posts/simplifying-use-effect/index.mdx
+++ b/content/posts/simplifying-use-effect/index.mdx
@@ -30,7 +30,7 @@ import Translations from 'components/Translations'
   ]}
 </Translations>
 
-[useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect). The hook everybody needs, but nobody wants. According to the official react docs, it's "_an escape hatch from React’s purely functional world into the imperative world_". The [complete guide to useEffect](https://overreacted.io/a-complete-guide-to-useeffect/) by Redux author and React core team member [Dan Abramov]( https://bsky.app/profile/danabra.mov) is a 49 minute read - and it takes at least twice the time to _really_ comprehend it.
+[useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect). The hook everybody needs, but nobody wants. According to the official react docs, it's "_an escape hatch from React’s purely functional world into the imperative world_". The [complete guide to useEffect](https://overreacted.io/a-complete-guide-to-useeffect/) by Redux author and React core team member [Dan Abramov](https://bsky.app/profile/danabra.mov) is a 49 minute read - and it takes at least twice the time to _really_ comprehend it.
 
 useEffect is about as complex as it can get in ReactJs, and it is very unlikely that you can write an application without it. So let's try and apply some good principles to make working with useEffect more manageable:
 


### PR DESCRIPTION
Further to https://github.com/TkDodo/blog/pull/317, I've updated the following Twitter links to the owners BlueSky accounts.

In each case:
- The person has an active [BlueSky](https://bsky.app) account
- The person has declared publicly that they are using BlueSky primarily over X/Twitter

There are some other twitter links possibly eligible for replacement but I've limited to very public declarations disowning X for this first pass.

List of moved accounts:

- Mark Ericson 
	- https://twitter.com/acemarke -> https://bsky.app/profile/acemarke.dev
	- https://x.com/acemarke/status/1860512437251735784
- Dan Abramov
	- https://twitter.com/dan_abramov - https://bsky.app/profile/danabra.mov
	- twitter account is dead (he was shadowbanned at one point accourding to https://youtu.be/F1sJW6nTP6E?t=720)
	- remember dan2?
	- actually works for Bluesky PBC
- Brian Vaughn 
	- https://twitter.com/brian_d_vaughn -> https://bsky.app/profile/brian.blue
	- https://x.com/brian_d_vaughn/status/1856730066799186026
	- bio states "I'm not here anymore. Find me on Bluesky."
- Jason Lengstorf
	- https://twitter.com/jlengstorf -> https://bsky.app/profile/jason.energy
	- https://x.com/jlengstorf/status/1854795085155623009