### PR TITLE
add japanese translation to "Automatic Query Invalidation after Mutations"

### DIFF
--- a/content/posts/automatic-query-invalidation-after-mutations/index.mdx
+++ b/content/posts/automatic-query-invalidation-after-mutations/index.mdx
@@ -40,6 +40,10 @@ import Tweet, { AvatarAlexDotJs } from 'components/Tweet'
     {
       language: '简体中文',
       url: 'https://juejin.cn/post/7388033492569325622'
+    },
+    {
+      language: '日本語',
+      url: 'https://makotot.dev/posts/automatic-query-invalidation-after-mutations-translation-ja',
     }
   ]}
 </Translations>


### PR DESCRIPTION
Translated https://tkdodo.eu/blog/automatic-query-invalidation-after-mutations into Japanese.