### PR TITLE
fix: update broken external link in putting-props-to-useState post

### DIFF
--- a/content/posts/putting-props-to-use-state/index.mdx
+++ b/content/posts/putting-props-to-use-state/index.mdx
@@ -105,7 +105,7 @@ render(<App />)
 You might notice right away that the example is _not_ working.
 You can edit the email address and click _Apply_, but if you click on _John_, the input field will not update.
 
-As much as React wants us to [think in hooks](https://wattenberger.com/blog/react-hooks) rather than in lifecycles,
+As much as React wants us to [think in hooks](https://2019.wattenberger.com/blog/react-hooks) rather than in lifecycles,
 when it comes to state, there is a big difference between the first render (also known as _mount_) and further renders
 (better known as _re-renders_).
 


### PR DESCRIPTION
## 🛠 Fix broken external link to "think in hooks" blog in **"Putting props to useState"** blog post

### 📝 Changes Made:
- Updated the outdated link to "think in hooks"
  **From:** [https://wattenberger.com/blog/react-hooks](https://wattenberger.com/blog/react-hooks)  
  **To:** [https://2019.wattenberger.com/blog/react-hooks](https://2019.wattenberger.com/blog/react-hooks)

### 🧐 Why is this change needed?
The previous link was no longer accessible, leading to a **404 page**. This update ensures that readers can still access the original article.
