### PR TITLE
Fix broken korean translation link of "Leveraging the Query Function Context"

### DIFF
--- a/content/posts/leveraging-the-query-function-context/index.mdx
+++ b/content/posts/leveraging-the-query-function-context/index.mdx
@@ -34,7 +34,7 @@ import Aside from 'components/Aside'
   {[
     {
       language: '한국어',
-      url: 'https://parang.gatsbyjs.io/react/2022-react-09/',
+      url: 'https://highjoon-dev.vercel.app/blogs/8a-leveraging-the-query-function-context',
     },
   ]}
 </Translations>


### PR DESCRIPTION
The Korean translation link of [`Leveraging the Query Function Context`](https://parang.gatsbyjs.io/react/2022-react-09/) is broken, so I was considering translating it, but I found that the #252 contributor had already translated it, so I only fixed the connection link.

I'm enjoying reading your posts. Thank you.