### PR TITLE
docs(ko): add korean translation link for react-query api desgin lesson learned

### DIFF
--- a/content/posts/react-query-api-design-lessons-learned/index.mdx
+++ b/content/posts/react-query-api-design-lessons-learned/index.mdx
@@ -26,7 +26,10 @@ import { RqToc } from 'components/rq-toc'
 
 <RqToc id="react-query-api-design-lessons-learned" />
 
-<Translations>{[]}</Translations>
+<Translations>{[    {
+      language: '한국어',
+      url: 'https://velog.io/@willy4202/%EB%B2%88%EC%97%AD-React-Query-API-%EB%94%94%EC%9E%90%EC%9D%B8-%EA%B7%B8-%EA%B5%90%ED%9B%88',
+    }]}</Translations>
 
 Here are the slides + transcript from the talk I recently gave at the [React Advanced](https://reactadvanced.com/) conference in London. You can swipe left or right or use the arrow buttons / arrow keys to switch between the slides. You can also find the recording on [the GitNation site](https://gitnation.com/contents/react-query-api-design-lessons-learned). Enjoy!
 


### PR DESCRIPTION
### Korean translation link: “React Query API Design – Lessons Learned”

**Live URL**  
[[번역] React Query API 디자인, 그 교훈](https://velog.io/@willy4202/%EB%B2%88%EC%97%AD-React-Query-API-%EB%94%94%EC%9E%90%EC%9D%B8-%EA%B7%B8-%EA%B5%90%ED%9B%88)

This PR adds a link to the Korean translation of the article **“React Query API Design – Lessons Learned.”**

At the very beginning of the translation I included the required notice:

> 🇰🇷 This article is a Korean translation of the original post “React Query API Design – Lessons Learned.”  
> Original: <https://tkdodo.eu/blog/react-query-api-design-lessons-learned>

**Translator:** Willy4202 