### PR TITLE
docs: add korean translation for 'deriving-client-state-from-server-state

### DIFF
--- a/content/posts/deriving-client-state-from-server-state/index.mdx
+++ b/content/posts/deriving-client-state-from-server-state/index.mdx
@@ -25,7 +25,12 @@ import Aside from 'components/Aside'
   url="https://unsplash.com/@hharritt"
 />
 
-<Translations>{[]}</Translations>
+<Translations>{[
+  {
+      language: "한국어",
+      url: "https://js-coding-place.tistory.com/entry/%EC%9B%90%EB%AC%B8-%EB%B2%88%EC%97%AD-%EC%84%9C%EB%B2%84-%EC%83%81%ED%83%9C%EC%97%90%EC%84%9C-%ED%81%B4%EB%9D%BC%EC%9D%B4%EC%96%B8%ED%8A%B8-%EB%81%8C%EC%96%B4%EC%98%A4%EA%B8%B0-tkdodo",
+    }
+]}</Translations>
 
 Just as I came back from vacation, I saw [this reddit question](https://www.reddit.com/r/reactjs/comments/1n4fz2m/is_this_the_biggest_tradeoff_for_zustand_am_i/) about the biggest trade-off when it comes to using `zustand`. The code looked something like this (I altered it slightly for updated syntax and packed it into a custom hook):
 


### PR DESCRIPTION
### Changes
Added a Korean translation for the article "Deriving Client State from Server State".

### Summary
This PR adds the Korean translation of Kent C. Dodds’ article on deriving client state from server state, providing Korean readers with the full explanation and examples in their native language.
