### PR TITLE
doc: add Korean translation for "tooltip-components-should-not-exist"

### DIFF
--- a/content/posts/tooltip-components-should-not-exist/index.mdx
+++ b/content/posts/tooltip-components-should-not-exist/index.mdx
@@ -33,6 +33,10 @@ import Highlight from '@components/Highlight'
       language: '日本語',
       url: 'https://makotot.dev/posts/tooltip-components-should-not-exist-translation-ja',
     },
+    {
+      language: '한국어',
+      url: 'https://blog.junijaei.co.kr/notes/translate/23',
+    },
   ]}
 />
 


### PR DESCRIPTION
This PR adds a Korean translation of the article **"Tooltip Components Should Not Exist"**.

Please let me know if any wording adjustments or terminology refinements are preferred.