### PR TITLE
fix : add missing translations prop to Translations component 

### DIFF
--- a/content/posts/creating-query-abstractions/index.mdx
+++ b/content/posts/creating-query-abstractions/index.mdx
@@ -31,14 +31,14 @@ import Tweet, {
 
 <RqToc id="creating-query-abstractions" />
 
-<Translations>
-  {[
+<Translations
+  translations={[
     {
       language: '한국어',
       url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-creating-query-abstractions/',
-    },
+    }
   ]}
-</Translations>
+/>
 
 Developers love creating abstractions. We see some code that we'll need in a different place - abstraction. Need this 3-liner, but slightly different - abstraction (with a flag). Need something that every `useQuery` should do - Create an <Emph>aBsTrAcTiOn</Emph>!
 

--- a/content/posts/creating-query-abstractions/index.mdx
+++ b/content/posts/creating-query-abstractions/index.mdx
@@ -36,7 +36,7 @@ import Tweet, {
     {
       language: '한국어',
       url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-creating-query-abstractions/',
-    }
+    },
   ]}
 />
 


### PR DESCRIPTION
Fixed a bug where the `translations` data was not being passed correctly to the `Translations` component.