### PR TITLE
fix: restore Korean translations with updated blog URL 

### DIFF
--- a/content/posts/2025-in-review/index.mdx
+++ b/content/posts/2025-in-review/index.mdx
@@ -25,7 +25,14 @@ import Tweet, {
   url="https://unsplash.com/@kellysikkema"
 />
 
-<Translations translations={[]} />
+<Translations
+  translations={[
+    {
+      language: '한국어',
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-2025-in-review/',
+    },
+  ]}
+/>
 
 It's that time of the year again - the time where I look back at what I did in the last 12 months. The good, the great and the perfect. Because, to be honest, 2025 was an amazing year for me. Let's start with my new job:
 

--- a/content/posts/context-inheritance-in-tan-stack-router/index.mdx
+++ b/content/posts/context-inheritance-in-tan-stack-router/index.mdx
@@ -23,7 +23,14 @@ import Aside from '@components/Aside'
 
 <TsrToc id="context-inheritance-in-tan-stack-router" />
 
-<Translations translations={[]} />
+<Translations
+  translations={[
+    {
+      language: '한국어',
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-context-inheritance-in-tanstack-router/',
+    },
+  ]}
+/>
 
 [TanStack Router](https://tanstack.com/router) has a lot of great features, so it's hard to pick favorites. That said, there is one thing that blew my mind once I saw it in action, and that is how the router lets you accumulate state between nested routes - not just at runtime, but also on type-level.
 

--- a/content/posts/designing-design-systems/index.mdx
+++ b/content/posts/designing-design-systems/index.mdx
@@ -25,7 +25,14 @@ import Highlight from '@components/Highlight'
 
 <DsToc id="designing-design-systems" />
 
-<Translations translations={[]} />
+<Translations
+  translations={[
+    {
+      language: '한국어',
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-designing-design-systems/',
+    },
+  ]}
+/>
 
 I'm not a Designer. Honestly, pixel-perfect work and anything involving CSS are not exactly my strong suit. I can barely open Figma, and when I do, I'm mainly clicking things and hoping for the best.😅
 

--- a/content/posts/the-beauty-of-tan-stack-router/index.mdx
+++ b/content/posts/the-beauty-of-tan-stack-router/index.mdx
@@ -35,6 +35,10 @@ import Aside from '@components/Aside'
       language: 'Tiếng Việt',
       url: 'https://www.kirugi.pro/posts/the-beauty-of-tan-stack-router/',
     },
+    {
+      language: "한국어",
+      url: "https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-beauty-of-tanstack-router/",
+    },
   ]}
 />
 

--- a/content/posts/the-beauty-of-tan-stack-router/index.mdx
+++ b/content/posts/the-beauty-of-tan-stack-router/index.mdx
@@ -36,8 +36,8 @@ import Aside from '@components/Aside'
       url: 'https://www.kirugi.pro/posts/the-beauty-of-tan-stack-router/',
     },
     {
-      language: "한국어",
-      url: "https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-beauty-of-tanstack-router/",
+      language: '한국어',
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-beauty-of-tanstack-router/',
     },
   ]}
 />

--- a/content/posts/the-useless-use-callback/index.mdx
+++ b/content/posts/the-useless-use-callback/index.mdx
@@ -33,6 +33,10 @@ import { VerticalRuler } from '@components/VerticalRuler'
       language: '繁體中文',
       url: 'https://sail-web-dev-archive.pages.dev/blog/the-useless-use-callback/',
     },
+    {
+      language: '한국어',
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-useless-usecallback/
+    },
   ]}
 />
 

--- a/content/posts/the-useless-use-callback/index.mdx
+++ b/content/posts/the-useless-use-callback/index.mdx
@@ -35,7 +35,7 @@ import { VerticalRuler } from '@components/VerticalRuler'
     },
     {
       language: '한국어',
-      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-useless-usecallback/
+      url: 'https://chapdo.vercel.app/posts/%EB%B2%88%EC%97%AD-the-useless-usecallback/',
     },
   ]}
 />


### PR DESCRIPTION
Sorry for the broken links
Re-adding Korean translations with the correct URL (`https://chapdo.vercel.app`). 
All links verified.