### PR TITLE
doc: add Korean translation for "TanStack Router and Query"

### DIFF
--- a/content/posts/tan-stack-router-and-query/index.mdx
+++ b/content/posts/tan-stack-router-and-query/index.mdx
@@ -25,12 +25,14 @@ import Emph from '@components/Emph'
 
 <TanStackRouterQueryToc />
 
-<Translations>{[
-  {
+<Translations>
+  {[
+    {
       language: '한국어',
       url: 'https://blog.junijaei.co.kr/notes/translate/30',
     },
-]}</Translations>
+  ]}
+</Translations>
 
 It shouldn't come as a surprise that TanStack Router integrates well with TanStack Query, after all, they're from the same <Emph>stack</Emph>. But wait a second - doesn't TanStack Router already come with support for caching?
 

--- a/content/posts/tan-stack-router-and-query/index.mdx
+++ b/content/posts/tan-stack-router-and-query/index.mdx
@@ -25,7 +25,12 @@ import Emph from '@components/Emph'
 
 <TanStackRouterQueryToc />
 
-<Translations>{[]}</Translations>
+<Translations>{[
+  {
+      language: '한국어',
+      url: 'https://blog.junijaei.co.kr/notes/translate/30',
+    },
+]}</Translations>
 
 It shouldn't come as a surprise that TanStack Router integrates well with TanStack Query, after all, they're from the same <Emph>stack</Emph>. But wait a second - doesn't TanStack Router already come with support for caching?
 

--- a/src/components/series-toc.tsx
+++ b/src/components/series-toc.tsx
@@ -174,10 +174,7 @@ function ListItemCurrent({ title }: ListItemProps) {
   );
 }
 
-function ListItemClickable({
-  title,
-  href,
-}: ListItemProps & { href: string }) {
+function ListItemClickable({ title, href }: ListItemProps & { href: string }) {
   return (
     <li className="!m-0 !p-0">
       <span className="block leading-relaxed">


### PR DESCRIPTION
This PR adds a Korean translation of the article "TanStack Router and Query".

Please let me know if any wording adjustments or terminology refinements are preferred.