### PR TITLE
fix: Fix syntax error in previously merged translation

### DIFF
--- a/content/posts/tan-stack-router-and-query/index.mdx
+++ b/content/posts/tan-stack-router-and-query/index.mdx
@@ -25,14 +25,14 @@ import Emph from '@components/Emph'
 
 <TanStackRouterQueryToc />
 
-<Translations>
-  {[
+<Translations
+  translations={[
     {
       language: '한국어',
       url: 'https://blog.junijaei.co.kr/notes/translate/30',
     },
   ]}
-</Translations>
+/>
 
 It shouldn't come as a surprise that TanStack Router integrates well with TanStack Query, after all, they're from the same <Emph>stack</Emph>. But wait a second - doesn't TanStack Router already come with support for caching?
 


### PR DESCRIPTION
## Overview

This PR fixes a syntax error in the previously merged translation contribution.

## Background

The previous PR for the translated article was merged successfully, but a syntax error caused the page to fail during rendering.

## Changes

- Fixed the syntax error in the translated article