### PR TITLE
Update invalid links in the practical React Query Article

### DIFF
--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -107,9 +107,7 @@ On top of that, it is also very flexible and lets you customize various settings
 This article is not going to be an introduction to React Query though.
 
 I think the docs are great at explaining Guides & Concepts,
-there are [Videos](https://tanstack.com/query/v4/docs/framework/react/videos) from various Talks that you can watch,
-and Tanner has a React Query [Essentials Course](https://learn.tanstack.com/) you can take if you want to get familiar with the library.
-
+there are [Videos](https://tanstack.com/query/v4/docs/framework/react/videos) from various Talks that you can watch.
 <Aside title="Update" icon="bell">
 
 I've been working on a brand new course together with [ui.dev](https://ui.dev/). If you enjoy the content I've been creating so far, you'll love [query.gg](https://query.gg/?s=dom).

--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -107,7 +107,7 @@ On top of that, it is also very flexible and lets you customize various settings
 This article is not going to be an introduction to React Query though.
 
 I think the docs are great at explaining Guides & Concepts,
-there are [Videos](https://tanstack.com/query/v4/docs/framework/react/videos) from various Talks that you can watch.
+there are [Videos](https://tanstack.com/query/latest/docs/community-resources#media) from various Talks that you can watch.
 <Aside title="Update" icon="bell">
 
 I've been working on a brand new course together with [ui.dev](https://ui.dev/). If you enjoy the content I've been creating so far, you'll love [query.gg](https://query.gg/?s=dom).

--- a/content/posts/practical-react-query/index.mdx
+++ b/content/posts/practical-react-query/index.mdx
@@ -107,7 +107,7 @@ On top of that, it is also very flexible and lets you customize various settings
 This article is not going to be an introduction to React Query though.
 
 I think the docs are great at explaining Guides & Concepts,
-there are [Videos](https://tanstack.com/query/latest/docs/react/videos) from various Talks that you can watch,
+there are [Videos](https://tanstack.com/query/v4/docs/framework/react/videos) from various Talks that you can watch,
 and Tanner has a React Query [Essentials Course](https://learn.tanstack.com/) you can take if you want to get familiar with the library.
 
 <Aside title="Update" icon="bell">


### PR DESCRIPTION
1. Fixed (https://tanstack.com/query/latest/docs/react/videos) -> (https://tanstack.com/query/v4/docs/framework/react/videos)

2. Removed the mention of https://learn.tanstack.com/ (The website is not working)